### PR TITLE
Makefile now compiles on Mac OS X 10.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN=smu
 LIB=smu.a
 
 SYS := $(shell gcc -dumpmachine)
-ifneq (, $(findstring linux, $(SYS)))
+ifneq (, $(findstring linux, $(SYS)) $(findstring darwin, $(SYS))) 
 	LINKFLAGS+=$(shell pkg-config --libs libusb-1.0)
 	CXXFLAGS+=$(shell pkg-config --cflags libusb-1.0)
 	PYCXXFLAGS=$(shell pkg-config --cflags python-2.7)
@@ -13,14 +13,6 @@ ifneq (, $(findstring linux, $(SYS)))
 	SHARE=libsmu.so
 	PYSHARE=libpysmu.so
 else
-	ifneq (, $(findstring darwin, $(SYS)))
-		LINKFLAGS+=$(shell pkg-config --libs libusb-1.0)
-		CXXFLAGS+=$(shell pkg-config --cflags libusb-1.0)
-		PYCXXFLAGS=$(shell pkg-config --cflags python-2.7)
-		PYLINKFLAGS=$(shell pkg-config --libs python-2.7)
-		SHARE=libsmu.so
-		PYSHARE=libpysmu.so
-	else
 		CXXFLAGS += -v -static -static-libgcc -static-libstdc++ -g
 		LINKFLAGS+="/usr/local/lib/libusb-1.0.a"
 		CXXFLAGS+=-I"C:\libusb\include\libusb-1.0"
@@ -28,7 +20,6 @@ else
 		PYLINKFLAGS="C:\Python27\libs\libpython27.a"
 		SHARE=libsmu.dll
 		PYSHARE=libpysmu.pyd
-endif
 endif
 
 
@@ -57,5 +48,3 @@ clean:
 python: $(LIB)
 	$(CXX) $(CXXFLAGS) $(PYCXXFLAGS) -o libpysmu.o -c pysmu.cpp
 	$(CXX) $(CXXFLAGS) -shared libpysmu.o $(LIB) $(LINKFLAGS) $(PYLINKFLAGS) -o $(PYSHARE)
-
-install:

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,24 @@ ifneq (, $(findstring linux, $(SYS)))
 	SHARE=libsmu.so
 	PYSHARE=libpysmu.so
 else
-	CXXFLAGS += -v -static -static-libgcc -static-libstdc++ -g
-	LINKFLAGS+="C:\libusb\MinGW32\static\libusb-1.0.a"
-	CXXFLAGS+=-I"C:\libusb\include\libusb-1.0"
-	PYCXXFLAGS=-I"C:\Python27\include"
-	PYLINKFLAGS="C:\Python27\libs\libpython27.a"
-	SHARE=libsmu.dll
-	PYSHARE=libpysmu.pyd
+	ifneq (, $(findstring darwin, $(SYS)))
+		LINKFLAGS+=$(shell pkg-config --libs libusb-1.0)
+		CXXFLAGS+=$(shell pkg-config --cflags libusb-1.0)
+		PYCXXFLAGS=$(shell pkg-config --cflags python-2.7)
+		PYLINKFLAGS=$(shell pkg-config --libs python-2.7)
+		SHARE=libsmu.so
+		PYSHARE=libpysmu.so
+	else
+		CXXFLAGS += -v -static -static-libgcc -static-libstdc++ -g
+		LINKFLAGS+="/usr/local/lib/libusb-1.0.a"
+		CXXFLAGS+=-I"C:\libusb\include\libusb-1.0"
+		PYCXXFLAGS=-I"C:\Python27\include"
+		PYLINKFLAGS="C:\Python27\libs\libpython27.a"
+		SHARE=libsmu.dll
+		PYSHARE=libpysmu.pyd
 endif
+endif
+
 
 SRC=session.cpp device_cee.cpp device_m1000.cpp cli.cpp
 OBJ=$(SRC:%.cpp=%.o)
@@ -28,7 +38,7 @@ OBJ=$(SRC:%.cpp=%.o)
 all: $(LIB) $(BIN) $(SHARE)
 
 $(LIB): $(OBJ)
-	ar crf $@ $^
+	ar cr $@ $^
 
 $(BIN): cli.o $(LIB)
 	$(CXX) -o $(BIN) $^ $(LINKFLAGS)
@@ -47,3 +57,5 @@ clean:
 python: $(LIB)
 	$(CXX) $(CXXFLAGS) $(PYCXXFLAGS) -o libpysmu.o -c pysmu.cpp
 	$(CXX) $(CXXFLAGS) -shared libpysmu.o $(LIB) $(LINKFLAGS) $(PYLINKFLAGS) -o $(PYSHARE)
+
+install:

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ With python2.7 and associated development headers installed, building pysmu.so, 
 
 Is recommended to install [homebrew](http://brew.sh)
 
-Once installed, install lib-usb `brew install lib-usb`, pkg-info `brew install pkg-info` and python `brew install python`, restart OS and then build LibSMU. 
+Once installed, install lib-usb `brew install lib-usb`, pkg-config `brew install pkg-config` and python `brew install python`, restart OS and then build LibSMU. 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ This project also includes 'pysmu,' an initial binding of LibSMU for Python2.7.
 With libusb-1.0, and clang++, building LibSMU and the demo 'smu' executable is as simple as typing `make`.
 
 With python2.7 and associated development headers installed, building pysmu.so, importable as `import pysmu` is as simple as typing `make python`.
+
+##### Notes on Mac OS X
+
+Is recommended to install [homebrew](http://brew.sh)
+
+Once installed, install lib-usb `brew install lib-usb`, pkg-info `brew install pkg-info` and python `brew install python`, restart OS and then build LibSMU. 


### PR DESCRIPTION
Same options for Darwin (Mac OS X) as for Linux.
Removed 'f' option in ar command not supported on Mac OS X.
Readme.md now includes a little info about requirements to compile on Mac OS X.