### PR TITLE
Rename the debug message printing function

### DIFF
--- a/src/device_m1000.cpp
+++ b/src/device_m1000.cpp
@@ -445,7 +445,7 @@ void M1000_Device::sync() {
 void M1000_Device::start_run(uint64_t samples) {
 	int ret = libusb_control_transfer(m_usb, 0x40, 0xC5, m_sam_per, m_sof_start, 0, 0, 100);
 	if (ret < 0) {
-		debug("control transfer failed with code %i\n", ret);
+		smu_debug("control transfer failed with code %i\n", ret);
 		return;
 	}
 	std::lock_guard<std::mutex> lock(m_state);
@@ -466,7 +466,7 @@ void M1000_Device::cancel() {
 	int ret_in = m_in_transfers.cancel();
 	int ret_out = m_out_transfers.cancel();
 	if ( (ret_in != ret_out) || (ret_in != 0) || (ret_out != 0) )
-		debug("cancel error in: %s out: %s\n", libusb_error_name(ret_in), libusb_error_name(ret_out));
+		smu_debug("cancel error in: %s out: %s\n", libusb_error_name(ret_in), libusb_error_name(ret_out));
 }
 
 /// put outputs into high-impedance mode, stop sampling

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -57,7 +57,7 @@ struct Transfers {
 			libusb_free_transfer(i);
 		}
 		if (num_active != 0)
-			debug("num_active after free: %i\n", num_active);
+			smu_debug("num_active after free: %i\n", num_active);
 		m_transfers.clear();
 	}
 
@@ -68,11 +68,11 @@ struct Transfers {
 		// for i in pending transfers
 		for (auto i: m_transfers) {
 			if (num_active > 1) {
-				debug("num_active before cancel: %i\n", num_active);
+				smu_debug("num_active before cancel: %i\n", num_active);
 				// libusb's cancel returns 0 if success, else an error code
 				int ret = libusb_cancel_transfer(i);
 				if (ret != 0) {
-					debug("canceled with status: %s\n", libusb_error_name(ret));
+					smu_debug("canceled with status: %s\n", libusb_error_name(ret));
 					// abort if a transfer is not successfully canceled
 					return ret;
 				}

--- a/src/libsmu.h
+++ b/src/libsmu.h
@@ -16,7 +16,7 @@
 #define DEBUG_TEST 0
 #endif
 
-#define debug(...) do { if (DEBUG_TEST) fprintf(stderr, __VA_ARGS__); } while(0);
+#define smu_debug(...) do { if (DEBUG_TEST) fprintf(stderr, __VA_ARGS__); } while(0);
 
 #ifdef __GNUC__
 #define __packed __attribute__((packed))


### PR DESCRIPTION
The 'debug' name is too generic and it can overwrite the definition of
other functions with the same name that might exist in the code that
includes libsmu.h.

Since not using namespaces rename the debug to smu_debug.

Signed-off-by: Dan Nechita <Dan.Nechita@analog.com>

The Qt qDebug() function is defined as:
#define qDebug QMessageLogger(QT_MESSAGELOG_FILE, QT_MESSAGELOG_LINE, QT_MESSAGELOG_FUNC).debug

and it looks like the debug() member of QMessageLogger is being replaced by the pre-processor with the definition from libsmu.h which causes compile errors.
