### PR TITLE
src/libsmu.hpp: Add missing step when generating staristep signal

### DIFF
--- a/src/libsmu.hpp
+++ b/src/libsmu.hpp
@@ -366,7 +366,7 @@ public:
 				return m_src_v2 - norm_phase * pkpk;
 
 			case SRC_STAIRSTEP:
-				return m_src_v2 - floorf(norm_phase*10)/10 * pkpk;
+				return m_src_v2 - floorf(norm_phase*10) * pkpk / 9;
 
 			case SRC_SINE:
 				return m_src_v1 + (1 + cos(norm_phase * 2 * M_PI)) * pkpk/2;


### PR DESCRIPTION
This fix makes sure that the last step of a stairstep signal is generated.

When norm_phase goes from [0.0, to 0.99..] floorf(norm_phase*10)/10
will go from [0.0 to 0.9]. This leads to the last stairstep never
being generated because of the missing 1.0 value.

Signed-off-by: Dan <Dan.Nechita@analog.com>