### PR TITLE
Fixed compiling issue related to C+11 on ArchLinux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ else()
 endif()
 project(libsmu CXX C)
 
+set (CMAKE_CXX_STANDARD 11)
+
 # libsmu versioning
 set(LIBSMU_VERSION_MAJOR 0)
 set(LIBSMU_VERSION_MINOR 8)

--- a/src/libsmu.hpp
+++ b/src/libsmu.hpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <cmath>
 #include <vector>
+#include <functional>
 
 using std::vector;
 


### PR DESCRIPTION
It seems that `functional` header must be included to properly compile under Arch Linux.
