### PR TITLE
Libsmu changes to access ADC and DAC config registers

### DIFF
--- a/bindings/python/pysmu/cpp_libsmu.pxd
+++ b/bindings/python/pysmu/cpp_libsmu.pxd
@@ -70,6 +70,7 @@ cdef extern from "libsmu/libsmu.hpp" namespace "smu" nogil:
         int write_calibration(const char* path)
         void calibration(vector[vector[float]]* cal)
         int set_led(unsigned leds)
+        int set_adc_mux(unsigned adc_mux)
 
     cdef cppclass Signal:
         sl_signal_info* info()

--- a/bindings/python/pysmu/libsmu.pyx
+++ b/bindings/python/pysmu/libsmu.pyx
@@ -40,14 +40,12 @@ class Mode(Enum):
     SVMI_SPLIT = 4
     SIMV_SPLIT = 5
 
-
 class LED(Enum):
     """Available device LEDs to control."""
     red = 47
     green = 29
     blue = 28
     all = 0
-
 
 cdef class Session:
     # pointer to the underlying C++ smu::Session object
@@ -498,6 +496,15 @@ cdef class Device:
         Raises: IOError on USB failures.
         """
         self._device.set_led(leds)
+
+    def set_adc_mux(self, adc_mux):
+        """Set ADC Mux mode.
+
+        Args:
+            adc_mux: an integer number, the number represents 1 of 7 poaaible adc MUX settings 
+        Raises: IOError on USB failures.
+        """
+        self._device.set_adc_mux(adc_mux)
 
     def ctrl_transfer(self, bm_request_type, b_request, wValue, wIndex,
                       data, wLength, timeout):
@@ -1276,6 +1283,19 @@ cdef class _DeviceSignal(Signal):
         """
         def __get__(self):
             return self._signal.info().max
+
+    property resolution:
+        """Get the signal's resolution value.
+
+        >>> from pysmu import Session, Mode
+        >>> dev = session.devices[0]
+        >>> chan_a = dev.channels['A']
+        >>> chan_a.mode = Mode.SVMI
+        >>> chan_a.signal.resolution
+        0.2
+        """
+        def __get__(self):
+            return self._signal.info().resolution
 
     @staticmethod
     cdef _create(cpp_libsmu.Signal *signal) with gil:

--- a/include/libsmu/libsmu.hpp
+++ b/include/libsmu/libsmu.hpp
@@ -445,6 +445,8 @@ namespace smu {
 		/// @brief Set the leds states for device.
         /// @param leds value between [0, 7], each bit of the value represents the state of an LED (1-on 0-off) in this order (RGB or DS3,DS2,DS1 on rev F hardware)
         virtual int set_led(unsigned leds) = 0;
+		/// set adc mux mode
+		virtual int set_adc_mux(unsigned adc_mux) = 0;
 
 	protected:
 		/// @brief Device constructor.

--- a/src/device_m1000.hpp
+++ b/src/device_m1000.hpp
@@ -66,6 +66,7 @@ namespace smu {
 		void calibration(std::vector<std::vector<float>>* cal) override;
 		int samba_mode() override;
         int set_led(unsigned leds) override;
+		int set_adc_mux(unsigned adc_mux); // New function added;
 
 	protected:
 		friend class Session;


### PR DESCRIPTION
Hi:
These changes, along with new features in m1k-fw, allow access to the ADC and DAC configuration registers to provide 200KSPS operation modes. I've tested these changes using Mingw32 compiler on Windows and they should not interfere with any existing software. I've made the changes with a minimalistic style sufficient to access the new features provided by my changes to m1k-fw. I think these are the only changes I ended up making. In the process of finding my way around and figuring out how to make the software tools work I may have touched other files and not remembered.

Setting up and using these 200KSPS configurations is more advanced than the typical user would be doing. I've added settings for 4 of the 6 possible combinations and another that just passes raw, unscaled and uncalibrated samples back for debugging and experimenting.

You may wish to make them more in the style consistent with the rest of the code in libsmu. Making style changes is fine as long as the same functionality is provided. Just let me know so I can make accommodations in my Python code (ALICE 1.3).

If you could make a sub-branch with the changes and make a Windows installer version of them (soon) that would be extremely helpful. Right now I have to use my changes only under Mingw32 and can't make stand alone Windows executable (using py2exe) from there. I need to be able to install a new libsmu under the Python in the Windows registry to use py2exe and make the Windows executable. I would like to install this new version of ALICE on another computer to use at the ECEDHA expo next month,

Thanks
Doug