### PR TITLE
Libusb hotplug removed and crash on close bug solved.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       cache: pip
     - os: linux
       sudo: required
-      dist: trusty
+      dist: xenial
       language: python
       python: 3.4
       env: PYTHON=python PIP=pip

--- a/bindings/python/pysmu/cpp_libsmu.pxd
+++ b/bindings/python/pysmu/cpp_libsmu.pxd
@@ -42,8 +42,6 @@ cdef extern from "libsmu/libsmu.hpp" namespace "smu" nogil:
         void flush()
         int flash_firmware(const char* path, vector[Device*]) except +
         int end()
-        void hotplug_attach(void (Device *dev, void *data) nogil, void *data)
-        void hotplug_detach(void (Device *dev, void *data) nogil, void *data)
 
     cdef cppclass Device:
         string m_serial

--- a/bindings/python/pysmu/libsmu.pyx
+++ b/bindings/python/pysmu/libsmu.pyx
@@ -91,28 +91,6 @@ cdef class Session:
         signal(SIGINT, SIG_DFL)
         os.kill(os.getpid(), SIGINT)
 
-    def hotplug_attach(self, *funcs):
-        """Register a function to run on a device attach event.
-
-        Attributes:
-            funcs: Python function(s) to run on device attach events. The
-                function should accept a single parameter, the device object
-                being attached.
-        """
-        for f in funcs:
-            self._session.hotplug_attach(self._hotplug_callback, <void*>f)
-
-    def hotplug_detach(self, *funcs):
-        """Register a function to run on a device detach event.
-
-        Attributes:
-            funcs: Python function(s) to run on device detach events. The
-                function should accept a single parameter, the device object
-                being detached.
-        """
-        for f in funcs:
-            self._session.hotplug_detach(self._hotplug_callback, <void*>f)
-
     @staticmethod
     cdef void _hotplug_callback(cpp_libsmu.Device *device, void *func) with gil:
         """Internal proxy to run the python hotplug functions from the C++ side."""

--- a/examples/hotplug.cpp
+++ b/examples/hotplug.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <algorithm>
 
 #include <libsmu/libsmu.hpp>
 
@@ -17,28 +18,52 @@ int main(int argc, char **argv)
 	// Create session object and add all compatible devices them to the
 	// session. Note that this currently doesn't handle returned errors.
 	Session* session = new Session();
-	session->add_all();
+	std::vector < Device* > last_devices;
 
-	// Register hotplug detach callback handler.
-	session->hotplug_detach([=](Device* device, void* data){
-		session->cancel();
-		if (!session->remove(device, true)) {
-			printf("device detached: %s: serial %s: fw %s: hw %s\n",
-				device->info()->label, device->m_serial.c_str(),
-				device->m_fwver.c_str(), device->m_hwver.c_str());
+	while (true) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+		session->scan();
+
+		std::vector < Device* > available_devices = session->m_available_devices;
+
+		//check if there is any disconnected device
+		for (auto other_device : last_devices) {
+			bool found = 0;
+
+			for (auto device : available_devices) {
+				if (!device->m_serial.compare(other_device->m_serial)) {
+					found = 1;
+					break;
+				}
+			}
+
+			if (!found) {
+				cout << "Device detached!\n";
+				last_devices.erase(std::remove(last_devices.begin(), last_devices.end(), other_device), last_devices.end());
+			}
 		}
-	});
 
-	// Register hotplug attach callback handler.
-	session->hotplug_attach([=](Device* device, void* data){
-		if (!session->add(device)) {
-			printf("device attached: %s: serial %s: fw %s: hw %s\n",
-				device->info()->label, device->m_serial.c_str(),
-				device->m_fwver.c_str(), device->m_hwver.c_str());
+		//check if there is any new connected device
+		for (auto device : available_devices) {
+			bool found = 0;
+
+			for (auto other_device : last_devices) {
+				if (!device->m_serial.compare(other_device->m_serial)) {
+					found = 1;
+					break;
+				}
+			}
+
+			if (!found) {
+				cout << "Device attached!\n";
+			}
+			else {
+				available_devices.erase(std::remove(available_devices.begin(), available_devices.end(), device), available_devices.end());
+				delete device;
+			}
 		}
-	});
 
-	cout << "waiting for hotplug events..." << endl;
-	while (true)
-		std::this_thread::sleep_for(std::chrono::seconds(1));
+		last_devices.insert(last_devices.end(), available_devices.begin(), available_devices.end());
+		cout << "Number of available devices: " << last_devices.size() << '\n';
+	}
 }

--- a/include/libsmu/libsmu.hpp
+++ b/include/libsmu/libsmu.hpp
@@ -130,7 +130,7 @@ namespace smu {
 		/// target usage. The default is approximately 100ms worth of samples
 		/// at the maximum sampling rate. Note that must be changed before
 		/// devices are added to a session otherwise they'll use the default.
-		unsigned m_queue_size = 10000;
+		unsigned m_queue_size = 100000;
 
 
         unsigned m_samples;

--- a/include/libsmu/libsmu.hpp
+++ b/include/libsmu/libsmu.hpp
@@ -256,11 +256,6 @@ namespace smu {
 		/// cancelled session.
 		std::function<void(unsigned)> m_completion_callback;
 
-		/// @brief Register USB hotplug attach callback.
-		void hotplug_attach(std::function<void(Device* device, void* data)> func, void *data = NULL);
-		/// @brief Register USB hotplug detach callback.
-		void hotplug_detach(std::function<void(Device* device, void* data)> func, void *data = NULL);
-
 		/// @brief Session sample rate.
 		uint64_t m_sample_rate = 0;
 

--- a/src/cli/smu.cpp
+++ b/src/cli/smu.cpp
@@ -180,8 +180,7 @@ int main(int argc, char **argv)
 	// map long options to short ones
 	static struct option long_options[] = {
 		{"help",     no_argument, 0, 'a'},
-		{"version",     no_argument, 0, 'v'},
-		{"hotplug",  no_argument, 0, 'p'},
+        {"version",     no_argument, 0, 'v'},
 		{"list",     no_argument, 0, 'l'},
 		{"stream",   no_argument, 0, 's'},
 		{"display-calibration", no_argument, 0, 'd'},
@@ -194,30 +193,6 @@ int main(int argc, char **argv)
 	while ((opt = getopt_long(argc, argv, "hvplsdrw:f:",
 			long_options, &option_index)) != -1) {
 		switch (opt) {
-			case 'p':
-				session->hotplug_detach([=](Device* device, void* data){
-					session->cancel();
-					if (!session->remove(device, true)) {
-						printf("removed device: %s: serial %s: fw %s: hw %s\n",
-							device->info()->label, device->m_serial.c_str(),
-							device->m_fwver.c_str(), device->m_hwver.c_str());
-					}
-				});
-
-				session->hotplug_attach([=](Device* device, void* data){
-					if (!session->add(device)) {
-						printf("added device: %s: serial %s: fw %s: hw %s\n",
-							device->info()->label, device->m_serial.c_str(),
-							device->m_fwver.c_str(), device->m_hwver.c_str());
-					}
-				});
-
-				cout << "waiting for hotplug events..." << endl;
-
-				// wait around doing nothing (hotplug testing)
-				while (1)
-					std::this_thread::sleep_for(std::chrono::seconds(10));
-				break;
 			case 'l':
 				// list attached device info
 				list_devices(session);


### PR DESCRIPTION
In this version, we have changed the hotplug mechanism from libsmu. This is because in the last versions of libusb, they have changed the way it works. On the latest versions, when a hotplug signal is emitted (and the callback is started), the device becomes busy, until the callback ends. This thing makes the hotplug mechanism from libsmu inoperative, because it is (almost) impossible to synchronize the callback end time and libsmu calls on the device. When this branch will be merged into master, we will not use the old version of libusb anymore and will use the latest available libusb version (link to the libusb github repository: https://github.com/libusb/libusb).

Therefore we have removed  the hotplug_attach and hotplug_detach methods from libsmu and the "-p, --hotplug-devices" option from the API.

In order to show how the hotplug mechanism works, we have modified the hotplug example as well, giving a possible method for simulating the hotplug process.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>