### PR TITLE
device_m1000.cpp: fix variable delay in multidevice configuration

### DIFF
--- a/src/device_m1000.cpp
+++ b/src/device_m1000.cpp
@@ -871,7 +871,7 @@ int M1000_Device::sync()
 
 	// get the location of the device's microframe
 	ret = ctrl_transfer(0xC0, 0x6F, 0, 0, (unsigned char*)&m_sof_start, 2, 100);
-	m_sof_start = (m_sof_start + 0xff) & 0x3c00;
+	m_sof_start = (((m_sof_start >> 3) + 0x1f) & 0x7FF) << 3;
 
 	return libusb_errno_or_zero(ret);
 }


### PR DESCRIPTION
This was previously fixed with commit 41e2924b933b00e7732c18825d0ea98ec82cf04e
however the change was lost after merge commit 6e5d7af7786f8a8b6b0390a1ea382ae10b52a17d

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>