### PR TITLE
bindings/python/setup.py: Always regenerate cython extensions.

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -124,13 +124,8 @@ class build_ext(dst_build_ext):
         return dst_build_ext.build_extensions(self)
 
     def run(self):
-        # only regenerate cython extensions if requested or required
-        USE_CYTHON = (
-            os.environ.get('USE_CYTHON', False) or
-            any(not os.path.exists(x) for ext in self.no_cythonize() for x in ext.sources))
-        if USE_CYTHON:
-            from Cython.Build import cythonize
-            cythonize(self.extensions)
+        from Cython.Build import cythonize
+        cythonize(self.extensions)
 
         self.extensions = self.no_cythonize()
         return dst_build_ext.run(self)


### PR DESCRIPTION
The cython file is generated in the first build. Any modification done in
the source files (libsmu.pyx for example) is not propagated to the
python bindings. In order to do so, the libsmu.cpp (generated) file
should be removed after every build.
To fix this, we configure setup.py to always regenerate the extension files.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>