### PR TITLE
Pysmu session constructor fix.

### DIFF
--- a/bindings/python/pysmu/libsmu.pyx
+++ b/bindings/python/pysmu/libsmu.pyx
@@ -74,6 +74,9 @@ cdef class Session:
             queue_size (int, optional): Size of input/output sample queues for
                 every device (defaults to 10000).
         """
+
+        self.queue_size = 100000
+
         if queue_size is not None:
             self.queue_size = queue_size
 


### PR DESCRIPTION
The queue_size parameter wasn't initialized with the default value and this fact was producing sometimes runtime errors.
We have fixed this and initialize it with the default value from libsmu.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>