### PR TITLE
Fix some session bugs

### DIFF
--- a/include/libsmu/libsmu.hpp
+++ b/include/libsmu/libsmu.hpp
@@ -342,6 +342,8 @@ namespace smu {
 		/// serial number
 		const std::string m_serial;
 
+		std::pair<uint8_t, uint8_t> m_usb_addr;
+
 		/// @brief Get the array of firmware version components (major, minor, patch).
 		/// Note that this method assumes semantic versioning so versions such
 		/// as 2.06 will be coerced to 2.6.0, i.e. major=2, minor=6, patch=0.
@@ -453,6 +455,8 @@ namespace smu {
         virtual int set_led(unsigned leds) = 0;
 		/// set adc mux mode
 		virtual int set_adc_mux(unsigned adc_mux) = 0;
+
+		virtual void set_usb_device_addr(std::pair<uint8_t, uint8_t> usb_addr) = 0;
 
 	protected:
 		/// @brief Device constructor.

--- a/include/libsmu/libsmu.hpp
+++ b/include/libsmu/libsmu.hpp
@@ -111,6 +111,8 @@ namespace smu {
 		Session();
 		~Session();
 
+		void set_off(Device*);
+
 		/// @brief Devices that are present on the system.
 		/// Note that these devices consist of all supported devices currently
 		/// recognized on the system; however, the devices aren't necessarily

--- a/src/device_m1000.cpp
+++ b/src/device_m1000.cpp
@@ -162,6 +162,7 @@ int M1000_Device::read_calibration()
 
 	if (ret > 0)
 		ret = 0;
+
 	return ret;
 }
 
@@ -1167,4 +1168,9 @@ int M1000_Device::set_adc_mux(unsigned adc_mux){
 	}
 
 	return 0;
+}
+
+void M1000_Device::set_usb_device_addr(std::pair<uint8_t, uint8_t> addr)
+{
+	m_usb_addr = addr;
 }

--- a/src/device_m1000.cpp
+++ b/src/device_m1000.cpp
@@ -85,6 +85,7 @@ M1000_Device::~M1000_Device()
 	// free USB transfers
 	m_in_transfers.clear();
 	m_out_transfers.clear();
+	unlock();
 }
 
 int M1000_Device::get_default_rate()
@@ -980,8 +981,10 @@ int M1000_Device::run(uint64_t samples)
 			cv.wait(lk, [&buf,&stop]{ return (buf.size() || stop < 0); });
 
 			// signaled to exit
-			if (stop < 0)
+			if (stop < 0) {
+				lk.unlock();
 				return;
+			}
 			stop = 0;
 start:
 			it = buf.begin();
@@ -1031,7 +1034,7 @@ end:
 				m_out_samples_cv[ch_i].notify_one();
 			}
 		}
-	}
+    }
 
 	return 0;
 }
@@ -1039,13 +1042,14 @@ end:
 int M1000_Device::cancel()
 {
     lock();
+
 	int ret_in = m_in_transfers.cancel();
 	int ret_out = m_out_transfers.cancel();
-    if ((ret_in != ret_out) || (ret_in != 0) || (ret_out != 0)){
+	if ((ret_in != ret_out) || (ret_in != 0) || (ret_out != 0)){
         unlock();
 		return -1;
-    }
-    unlock();
+	}
+	unlock();
 	return 0;
 }
 

--- a/src/device_m1000.hpp
+++ b/src/device_m1000.hpp
@@ -65,8 +65,9 @@ namespace smu {
 		int read_calibration() override;
 		void calibration(std::vector<std::vector<float>>* cal) override;
 		int samba_mode() override;
-        int set_led(unsigned leds) override;
+		int set_led(unsigned leds) override;
 		int set_adc_mux(unsigned adc_mux); // New function added;
+		void set_usb_device_addr(std::pair<uint8_t, uint8_t> usb_addr);
 
 	protected:
 		friend class Session;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -393,6 +393,11 @@ Device* Session::probe_device(libusb_device* usb_dev)
 		 *		Check this when newer libusb versions are released.
 		 */
 
+
+		uint8_t addr = libusb_get_device_address(usb_dev);
+		uint8_t bus = libusb_get_bus_number(usb_dev);
+		std::pair<uint8_t, uint8_t> usb_id_addr(bus, addr);
+
 		int open_errorcode = libusb_open(usb_dev, &usb_handle);
 
 		// probably lacking permission to open the underlying usb device
@@ -401,6 +406,13 @@ Device* Session::probe_device(libusb_device* usb_dev)
 				return NULL;
 			} else {
 				usb_handle = m_deviceHandles[usb_dev];
+			}
+		}
+
+		for (auto d : m_devices) {
+			if ((d->m_usb_addr.first == usb_id_addr.first) &&
+				(d->m_usb_addr.second == usb_id_addr.second)) {
+				return d;
 			}
 		}
 
@@ -422,6 +434,7 @@ Device* Session::probe_device(libusb_device* usb_dev)
 			return NULL;
 
 		dev = new M1000_Device(this, usb_dev, usb_handle, hwver, fwver, serial);
+		dev->set_usb_device_addr(usb_id_addr);
 		dev->read_calibration();
 		return dev;
 	}


### PR DESCRIPTION
1) Scanning while a device was already running distorted the signal (probably because of the control_transfer call - done in order to get the serial device). We modified the scanning to identify devices based on USB bus_id an USB address. 

2) Unplugging a device from a multi device session caused the application to block because of a mutex which was not properly unlocked.