### PR TITLE
Firmware update bug fix.

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -165,7 +165,6 @@ int Session::scan_samba_devs(std::vector<libusb_device*>& samba_devs)
 		}
 	}
 
-	libusb_free_device_list(usb_devs, 1);
 	return samba_devs.size();
 }
 


### PR DESCRIPTION
When scanning for samba devices Pixelpulse freed the found device list making them unable to be flashed.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>