### PR TITLE
CMakeLists.txt: Use "/usr/local" as the default install path instead of "/usr".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,9 @@ set(WITH_DOC OFF CACHE BOOL "Generate documentation with Doxygen")
 
 include(GNUInstallDirs)
 
-# set default install path to /usr
+# set default install path to /usr/local
 if (NOT WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "default install path" FORCE)
+	set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "default install path" FORCE)
 endif()
 
 # handle RPATH issues on OS X


### PR DESCRIPTION


Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>