### PR TITLE
session.cpp: fixed cancellation bug.

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -579,7 +579,8 @@ int Session::end()
 {
 	int ret = 0;
 	// cancel continuous sessions before ending them
-	if (m_continuous && m_cancellation) {
+	if (m_continuous) {
+		cancel();
 		m_continuous = false;
 	}
 


### PR DESCRIPTION
The cancel() call is needed in order to cancel the current transfers from each connected device before turning them off, when running in a continuous fashion. This prevents libsmu from getting into a deadlock because of the m_state mutex locked in the run() method.
The m_cancellation flag must be removed from the if-statement because it is only set in the device->cancel() method, preventing the program from entering this if statement.

This bug was introduced in [0548b85](https://github.com/analogdevicesinc/libsmu/commit/b8e7e2e2f0e1a1940bcf1ca2d1bd555ccd1a6bc2). The introduced bug has hidden by Pixelpulse, which I have used to test that modification. In Pixelpulse, session->close() was called before session->end(), solving the above mentioned threading issue.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>