### PR TITLE
Fix typo in Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Based on this base library installation, you can install the Python bindings man
 Install prerequisites
 ```shell
 analog@analog:~$ sudo apt-get update
-analog@analog:~$ sudo apt-get install libusb-1.0-0-dev libboost-all-dev cmake pkgconfig
+analog@analog:~$ sudo apt-get install libusb-1.0-0-dev libboost-all-dev cmake pkg-config
 ```
 Install to build Python bindings
 ```shell


### PR DESCRIPTION
The command in the documentation for installing the linux dependencies has a typo
Fixes #172