### PR TITLE
Appveyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,10 @@ install:
   - choco install InnoSetup
   - set PATH=%PATH%;C:\Program Files (x86)\Inno Setup 5
 
+  # Download dpinst for Driver installing from swdownloads
+  - appveyor DownloadFile http://swdownloads.analog.com/cse/m1k/drivers/dpinst.zip -FileName C:\dpinst.zip
+  - 7z x -y "c:\dpinst.zip" -o"c:\dpinst" > nul
+
 build_script:
   # build our own libusb version with hotplug support until upstream merges related patches
   # see https://github.com/libusb/libusb/issues/86
@@ -100,6 +104,8 @@ build_script:
   - copy ..\dist\amd64\* c:\libsmu\drivers\amd64
   - if not exist "c:\libsmu\drivers\x86" mkdir c:\libsmu\drivers\x86
   - copy ..\dist\x86\* c:\libsmu\drivers\x86
+  - copy C:\dpinst\dpinst.exe c:\libsmu\drivers
+  - copy C:\dpinst\dpinst_amd64.exe c:\libsmu\drivers
 
   # libraries
   - copy C:\\libusb\\Win32\\Release\\lib\\libusb-1.0.* c:\libsmu\32
@@ -355,7 +361,6 @@ build_script:
   # create libsmu installers
   - copy C:\projects\libsmu\32\dist\libsmu-x86.iss C:\projects\libsmu\dist\libsmu-x86.iss
   - copy C:\projects\libsmu\32\dist\libsmu-x64.iss C:\projects\libsmu\dist\libsmu-x64.iss
-  - copy C:\Windows\System32\pnputil.exe C:\projects\libsmu\dist\pnputil.exe
   - iscc C:\projects\libsmu\dist\libsmu-x86.iss
   - iscc C:\projects\libsmu\dist\libsmu-x64.iss
   - ren C:\libsmu-setup-x86.exe libsmu-%LIBSMU_VERSION%-setup-x86.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2019
 clone_depth: 1
 
 #init:
@@ -28,27 +28,28 @@ install:
   - git clone https://github.com/libusb/libusb.git "C:\libusb"
   # install innosetup for creating installers
   - choco install InnoSetup
-  - set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 5"
+  - set PATH=%PATH%;C:\Program Files (x86)\Inno Setup 5
 
 build_script:
   # build our own libusb version with hotplug support until upstream merges related patches
   # see https://github.com/libusb/libusb/issues/86
   - ps: pushd "C:\libusb"
-  - git checkout v1.0.21
-  - msbuild msvc\libusb_2015.sln /p:Platform=Win32 /p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - msbuild msvc\libusb_2015.sln /p:Platform=x64 /p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - git checkout v1.0.23
+  - MsBuild msvc\libusb_2017.sln /p:Platform=Win32 /p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - MsBuild msvc\libusb_2017.sln /p:Platform=x64 /p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   - ps: popd
 
   # build 32-bit version of libsmu -- python bindings are built separately
   - mkdir c:\projects\libsmu\32
   - cd c:\projects\libsmu\32
-  - cmake -G "Visual Studio 14 2015" \
+  - cmake -G "Visual Studio 16 2019" \
+    -A Win32 \
     -DCMAKE_BUILD_TYPE:STRING=%CONFIGURATION% \
     -DCMAKE_SYSTEM_PREFIX_PATH="C:" \
     -DLIBUSB_LIBRARIES="C:\\libusb\\Win32\\Release\\lib\\libusb-1.0.lib" \
     -DLIBUSB_INCLUDE_DIRS="C:\\libusb\\libusb" \
-    -DBOOST_ROOT="C:\\Libraries\\boost_1_62_0" \
-    -DBOOST_LIBRARYDIR="C:\\Libraries\\boost_1_62_0\\lib32-msvc-14.0" \
+    -DBOOST_ROOT="C:\\Libraries\\boost_1_73_0" \
+    -DBOOST_LIBRARYDIR="C:\\Libraries\\boost_1_73_0\\lib32-msvc-14.2" \
     -DBoost_USE_STATIC_LIBS=ON \
     -DBUILD_STATIC_LIB=ON \
     -DBUILD_EXAMPLES=ON \
@@ -63,13 +64,14 @@ build_script:
   # build 64-bit version of libsmu -- python bindings are built separately
   - mkdir c:\projects\libsmu\64
   - cd c:\projects\libsmu\64
-  - cmake -G "Visual Studio 14 2015 Win64" \
+  - cmake -G "Visual Studio 16 2019" \
+    -A x64 \
     -DCMAKE_BUILD_TYPE:STRING=%CONFIGURATION% \
     -DCMAKE_SYSTEM_PREFIX_PATH="C:" \
     -DLIBUSB_LIBRARIES="C:\\libusb\\x64\\Release\\lib\\libusb-1.0.lib" \
     -DLIBUSB_INCLUDE_DIRS="C:\\libusb\\libusb" \
-    -DBOOST_ROOT="C:\\Libraries\\boost_1_62_0" \
-    -DBOOST_LIBRARYDIR="C:\\Libraries\\boost_1_62_0\\lib64-msvc-14.0" \
+    -DBOOST_ROOT="C:\\Libraries\\boost_1_73_0" \
+    -DBOOST_LIBRARYDIR="C:\\Libraries\\boost_1_73_0\\lib64-msvc-14.2" \
     -DBoost_USE_STATIC_LIBS=ON \
     -DBUILD_STATIC_LIB=ON \
     -DBUILD_EXAMPLES=ON \
@@ -124,18 +126,20 @@ build_script:
   - copy ..\tests\run-tests.bat c:\libsmu\32
   - copy ..\tests\run-tests.bat c:\libsmu\64
   # windows specific redistributable libraries
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x86\\Microsoft.VC140.CRT\\msvcp140.dll"; c:\libsmu\32
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x86\\Microsoft.VC140.OPENMP\\vcomp140.dll"; c:\libsmu\32
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x86\\Microsoft.VC140.CRT\\vcruntime140.dll"; c:\libsmu\32
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x64\\Microsoft.VC140.CRT\\msvcp140.dll"; c:\libsmu\64
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x64\\Microsoft.VC140.OPENMP\\vcomp140.dll"; c:\libsmu\64
-  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist\\x64\\Microsoft.VC140.CRT\\vcruntime140.dll"; c:\libsmu\64
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x86\\Microsoft.VC142.CRT\\msvcp140.dll"; c:\libsmu\32
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x86\\Microsoft.VC142.OPENMP\\vcomp140.dll"; c:\libsmu\32
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x86\\Microsoft.VC142.CRT\\vcruntime140.dll"; c:\libsmu\32
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x64\\Microsoft.VC142.CRT\\msvcp140.dll"; c:\libsmu\64
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x64\\Microsoft.VC142.OpenMP\\vcomp140.dll"; c:\libsmu\64
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x64\\Microsoft.VC142.CRT\\vcruntime140.dll"; c:\libsmu\64
+  - copy "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Redist\\MSVC\\14.28.29325\\x64\\Microsoft.VC142.CRT\\vcruntime140_1.dll"; c:\libsmu\64
   - copy "C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\DLLs\\x86\\*" c:\libsmu\32
   - copy "C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\DLLs\\x64\\*" c:\libsmu\64
+
   - 7z a "c:\libsmu-%LIBSMU_VERSION%.zip" c:\libsmu
   - appveyor PushArtifact c:\libsmu-%LIBSMU_VERSION%.zip
 
-  # build 32 and 64 bit pysmu modules for all supported python versions, currently 2.7, 3.6, and 3.7
+  # build 32 and 64 bit pysmu modules for all supported python versions, currently 2.7, 3.7, and 3.8
   # TODO: drop the duplication and loop over supported python versions
   - mkdir c:\libsmu-python
   # check the python versions installed on appveyor
@@ -158,7 +162,7 @@ build_script:
   - ps: pushd C:\projects\libsmu\bindings\python
   - set DISTUTILS_USE_SDK=1
   - set MSSdk=1
-  - set PATH=C:\Program Files (x86)\MSBuild\14.0\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC;%PATH%
+  - set PATH=C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build;%PATH%
   - set OLDPATH=%PATH%
 
   - "vcvarsall.bat x86"
@@ -175,39 +179,6 @@ build_script:
   - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win32.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win32-py"
   - set PATH=%OLDPATH%
 
-  ## build 32 bit python3.6 bindings
-  # add python dirs to PATH
-  - set PATH=C:\\Python36;C:\\Python36\\Scripts;%PATH%
-  # check we're using the right python version and arch
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-
-  # update pip to keep it from complaining
-  - "c:/python36/python.exe -m pip install --only-binary :all: --disable-pip-version-check --user --upgrade pip"
-  # wheel needs to be installed in order to build binary wheels for pysmu
-  - "c:/python36/python.exe -m pip install --only-binary :all: wheel"
-  # cython is required for generating the extensions
-  - "c:/python36/python.exe -m pip install --only-binary :all: cython"
-  # py2exe required to build exe from pysmu script
-  - "c:/python36/python.exe -m pip install --only-binary :all: py2exe"
-  - "c:/python36/python.exe -m pip install pyreadline"
-
-  - "vcvarsall.bat x86"
-  - "python setup.py build_ext --compiler=msvc -L ../../32/src/%CONFIGURATION% -I C:\\libusb\\libusb"
-  - "python setup.py build"
-  - "python setup.py bdist_wheel --skip-build"
-  - "python setup.py bdist --skip-build --format zip"
-  - "python setup.py bdist --skip-build --format msi"
-  - "python setup.py sdist"
-
-  # test local install
-  - ps: Get-ChildItem dist/*-cp36-*-win32.whl | % { pip install "$_" }
-  # build exe from python script
-  # "build_exe -b 0 -d exe32 bin/pysmu"
-  # rmdir /q /s bin\__pycache__
-  - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win32.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win32-py"
-  - set PATH=%OLDPATH%
-
   ## build 32 bit python3.7 bindings
   # add python dirs to PATH
   - set PATH=C:\\Python37;C:\\Python37\\Scripts;%PATH%
@@ -221,6 +192,9 @@ build_script:
   - "c:/python37/python.exe -m pip install --only-binary :all: wheel"
   # cython is required for generating the extensions
   - "c:/python37/python.exe -m pip install --only-binary :all: cython"
+  # py2exe required to build exe from pysmu script
+  - "c:/python37/python.exe -m pip install --only-binary :all: py2exe"
+  - "c:/python37/python.exe -m pip install pyreadline"
 
   - "vcvarsall.bat x86"
   - "python setup.py build_ext --compiler=msvc -L ../../32/src/%CONFIGURATION% -I C:\\libusb\\libusb"
@@ -232,6 +206,39 @@ build_script:
 
   # test local install
   - ps: Get-ChildItem dist/*-cp37-*-win32.whl | % { pip install "$_" }
+  # build exe from python script
+  # "build_exe -b 0 -d exe32 bin/pysmu"
+  # rmdir /q /s bin\__pycache__
+  - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win32.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win32-py"
+  - set PATH=%OLDPATH%
+
+  ## build 32 bit python3.8 bindings
+  # add python dirs to PATH
+  - set PATH=C:\\Python38;C:\\Python38\\Scripts;%PATH%
+  # check we're using the right python version and arch
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # update pip to keep it from complaining
+  - "c:/python38/python.exe -m pip install --only-binary :all: --disable-pip-version-check --user --upgrade pip"
+  # wheel needs to be installed in order to build binary wheels for pysmu
+  - "c:/python38/python.exe -m pip install --only-binary :all: wheel"
+  # cython is required for generating the extensions
+  - "c:/python38/python.exe -m pip install --only-binary :all: cython"
+  # py2exe required to build exe from pysmu script
+  - "c:/python37/python.exe -m pip install --only-binary :all: py2exe"
+  - "c:/python37/python.exe -m pip install pyreadline"
+
+  - "vcvarsall.bat x86"
+  - "python setup.py build_ext --compiler=msvc -L ../../32/src/%CONFIGURATION% -I C:\\libusb\\libusb"
+  - "python setup.py build"
+  - "python setup.py bdist_wheel --skip-build"
+  - "python setup.py bdist --skip-build --format zip"
+  - "python setup.py bdist --skip-build --format msi"
+  - "python setup.py sdist"
+
+  # test local install
+  - ps: Get-ChildItem dist/*-cp38-*-win32.whl | % { pip install "$_" }
   - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win32.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win32-py"
   - 7z a -y "c:\projects\libsmu\bindings\python\dist\pysmu-%LIBSMU_VERSION%.win32-py.zip" pysmu-*win32-py
   - C:\msys64\usr\bin\bash -lc "rm dist/pysmu*win32.zip"
@@ -266,39 +273,6 @@ build_script:
   - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win-amd64.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win-amd64-py"
   - set PATH=%OLDPATH%
 
-  ## build 64 bit python3.6 bindings
-  # add python dirs to PATH
-  - set PATH=C:\\python36-x64;C:\\python36-x64\\Scripts;%PATH%
-  # check we're using the right python version and arch
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-
-  # update pip to keep it from complaining
-  - "c:/python36-x64/python.exe -m pip install --only-binary :all: --disable-pip-version-check --user --upgrade pip"
-  # wheel needs to be installed in order to build binary wheels for pysmu
-  - "c:/python36-x64/python.exe -m pip install --only-binary :all: wheel"
-  # cython is required for generating the extensions
-  - "c:/python36-x64/python.exe -m pip install --only-binary :all: cython"
-  # py2exe required to build exe from pysmu script
-  - "c:/python36-x64/python.exe -m pip install --only-binary :all: py2exe"
-  - "c:/python36-x64/python.exe -m pip install pyreadline"
-
-  - "vcvarsall.bat x64"
-  - "python setup.py build_ext --compiler=msvc -L ../../64/src/%CONFIGURATION% -I C:\\libusb\\libusb"
-  - "python setup.py build"
-  - "python setup.py bdist_wheel --skip-build"
-  - "python setup.py bdist --skip-build --format zip"
-  - "python setup.py bdist --skip-build --format msi"
-  - "python setup.py sdist"
-
-  # test local install
-  - ps: Get-ChildItem dist/*-cp36-*-win_amd64.whl | % { pip install "$_" }
-  # build exe from python script
-  # "build_exe -b 0 -d exe64 bin/pysmu"
-  # rmdir /q /s bin\__pycache__
-  - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win-amd64.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win-amd64-py"
-  - set PATH=%OLDPATH%
-
   ## build 64 bit python3.7 bindings
   # add python dirs to PATH
   - set PATH=C:\\python37-x64;C:\\python37-x64\\Scripts;%PATH%
@@ -312,6 +286,9 @@ build_script:
   - "c:/python37-x64/python.exe -m pip install --only-binary :all: wheel"
   # cython is required for generating the extensions
   - "c:/python37-x64/python.exe -m pip install --only-binary :all: cython"
+  # py2exe required to build exe from pysmu script
+  - "c:/python37-x64/python.exe -m pip install --only-binary :all: py2exe"
+  - "c:/python37-x64/python.exe -m pip install pyreadline"
 
   - "vcvarsall.bat x64"
   - "python setup.py build_ext --compiler=msvc -L ../../64/src/%CONFIGURATION% -I C:\\libusb\\libusb"
@@ -323,6 +300,36 @@ build_script:
 
   # test local install
   - ps: Get-ChildItem dist/*-cp37-*-win_amd64.whl | % { pip install "$_" }
+  # build exe from python script
+  # "build_exe -b 0 -d exe64 bin/pysmu"
+  # rmdir /q /s bin\__pycache__
+  - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win-amd64.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win-amd64-py"
+  - set PATH=%OLDPATH%
+
+  ## build 64 bit python3.8 bindings
+  # add python dirs to PATH
+  - set PATH=C:\\python38-x64;C:\\python38-x64\\Scripts;%PATH%
+  # check we're using the right python version and arch
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # update pip to keep it from complaining
+  - "c:/python38-x64/python.exe -m pip install --only-binary :all: --disable-pip-version-check --user --upgrade pip"
+  # wheel needs to be installed in order to build binary wheels for pysmu
+  - "c:/python38-x64/python.exe -m pip install --only-binary :all: wheel"
+  # cython is required for generating the extensions
+  - "c:/python38-x64/python.exe -m pip install --only-binary :all: cython"
+
+  - "vcvarsall.bat x64"
+  - "c:/python38-x64/python.exe setup.py build_ext --compiler=msvc -L ../../64/src/%CONFIGURATION% -I C:\\libusb\\libusb"
+  - "c:/python38-x64/python.exe setup.py build"
+  - "c:/python38-x64/python.exe setup.py bdist_wheel --skip-build"
+  - "c:/python38-x64/python.exe setup.py bdist --skip-build --format zip"
+  - "c:/python38-x64/python.exe setup.py bdist --skip-build --format msi"
+  - "c:/python38-x64/python.exe setup.py sdist"
+
+  # test local install
+  - ps: Get-ChildItem dist/*-cp38-*-win_amd64.whl | % { pip install "$_" }
   - 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*win-amd64.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%.win-amd64-py"
   - 7z a -y "c:\projects\libsmu\bindings\python\dist\pysmu-%LIBSMU_VERSION%.win-amd64-py.zip" pysmu-*win-amd64-py
   - C:\msys64\usr\bin\bash -lc "rm dist/pysmu*win-amd64.zip"
@@ -339,15 +346,16 @@ build_script:
   # copy python binding MSIs for installer
   - ps: Copy-Item dist\pysmu-*amd64-py2.7.msi c:\libsmu-python\pysmu27-amd64.msi
   - ps: Copy-Item dist\pysmu-*win32-py2.7.msi c:\libsmu-python\pysmu27-win32.msi
-  - ps: Copy-Item dist\pysmu-*amd64-py3.6.msi c:\libsmu-python\pysmu36-amd64.msi
-  - ps: Copy-Item dist\pysmu-*win32-py3.6.msi c:\libsmu-python\pysmu36-win32.msi
   - ps: Copy-Item dist\pysmu-*amd64-py3.7.msi c:\libsmu-python\pysmu37-amd64.msi
   - ps: Copy-Item dist\pysmu-*win32-py3.7.msi c:\libsmu-python\pysmu37-win32.msi
+  - ps: Copy-Item dist\pysmu-*amd64-py3.8.msi c:\libsmu-python\pysmu38-amd64.msi
+  - ps: Copy-Item dist\pysmu-*win32-py3.8.msi c:\libsmu-python\pysmu38-win32.msi
   - ps: popd
 
   # create libsmu installers
   - copy C:\projects\libsmu\32\dist\libsmu-x86.iss C:\projects\libsmu\dist\libsmu-x86.iss
   - copy C:\projects\libsmu\32\dist\libsmu-x64.iss C:\projects\libsmu\dist\libsmu-x64.iss
+  - copy C:\Windows\System32\pnputil.exe C:\projects\libsmu\dist\pnputil.exe
   - iscc C:\projects\libsmu\dist\libsmu-x86.iss
   - iscc C:\projects\libsmu\dist\libsmu-x64.iss
   - ren C:\libsmu-setup-x86.exe libsmu-%LIBSMU_VERSION%-setup-x86.exe
@@ -358,13 +366,6 @@ build_script:
   ##### MinGW build
   - set OPT_PATH=C:\msys64\mingw32\bin;C:\msys64\mingw64\bin;
   - set PATH=%OPT_PATH%%PATH%
-  # Manually updating Msys' keyring. This should be removed when appveyor updates the installer.
-  - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz"
-  - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  - cmd: C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-  - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
-  - cmd: C:\msys64\usr\bin\bash -lc "pacman-key --populate"
-  - cmd: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
 
   # Install MinGW dependencies for 32 bit
@@ -372,31 +373,24 @@ build_script:
   - C:\msys64\usr\bin\bash -lc "rm /mingw32/etc/gdbinit"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-pkg-config mingw-w64-i686-python2-pip mingw-w64-i686-openblas mingw-w64-i686-lapack"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy mingw-w64-i686-python3 mingw-w64-i686-python3-pip mingw-w64-i686-binutils mingw-w64-i686-curl"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/i686/mingw-w64-i686-libusb-1.0.21-1-any.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/mingw/i686/mingw-w64-i686-libusb-1.0.23-1-any.pkg.tar.xz"
 
   # Install MinGW dependencies for 64 bit
   - C:\msys64\usr\bin\bash -lc "pacman -Rs --noconfirm mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-libgfortran mingw-w64-x86_64-gcc-objc"
   - C:\msys64\usr\bin\bash -lc "rm /mingw64/etc/gdbinit"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config mingw-w64-x86_64-python2-pip mingw-w64-x86_64-openblas mingw-w64-x86_64-lapack"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy mingw-w64-x86_64-python3 mingw-w64-x86_64-python3-pip mingw-w64-x86_64-binutils mingw-w64-x86_64-curl"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libusb-1.0.21-1-any.pkg.tar.xz"
-
-  # Get libusb hotplug for 32 bit
-  #- ps: (new-object System.Net.WebClient).Downloadfile("http://swdownloads.analog.com/cse/build/libusb-1.0-hp.7z", "c:\libusb.7z")
-  #- 7z x -y "c:\libusb.7z" -o"C:\libusb-mingw" > nul
-  # Compile libusb hotplug for 64 bit
-  - git clone --branch=hotplug https://github.com/analogdevicesinc/libusb.git "C:\libusb-mingw64"
-  - C:\msys64\usr\bin\bash -lc "cd C:/libusb-mingw64 && ./autogen.sh && ./configure --prefix=/mingw64 --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 && make -j4"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libusb-1.0.23-1-any.pkg.tar.xz"
 
   # Build libsmu MinGW 32 bit
   - echo "Running cmake for MinGW 32..."
   - mkdir c:\projects\libsmu\mingw-32
-  - C:\msys64\usr\bin\bash -lc "cd C:/projects/libsmu/mingw-32 && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=/mingw32 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_C_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-g++.exe -DLIBUSB_LIBRARIES=C:/msys64/mingw32/lib/libusb-1.0.dll.a -DLIBUSB_INCLUDE_DIRS=C:/msys64/mingw32/include/libusb-1.0 -DBoost_USE_STATIC_LIBS=ON -DBUILD_STATIC_LIB=ON -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DBOOST_ROOT=C:/Libraries/boost_1_62_0 -DBUILD_PYTHON=OFF .. && cmake --build . --config %CONFIGURATION%"
+  - C:\msys64\usr\bin\bash -lc "cd C:/projects/libsmu/mingw-32 && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=/mingw32 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_C_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-g++.exe -DLIBUSB_LIBRARIES=C:/msys64/mingw32/lib/libusb-1.0.dll.a -DLIBUSB_INCLUDE_DIRS=C:/msys64/mingw32/include/libusb-1.0 -DBoost_USE_STATIC_LIBS=ON -DBUILD_STATIC_LIB=ON -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DBOOST_ROOT=C:/Libraries/boost_1_73_0 -DBUILD_PYTHON=OFF .. && cmake --build . --config %CONFIGURATION%"
 
   # Build libsmu MinGW 64 bit
   - echo "Running cmake for MinGW 64..."
   - mkdir c:\projects\libsmu\mingw-64
-  - C:\msys64\usr\bin\bash -lc "cd C:/projects/libsmu/mingw-64 && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=/mingw64 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_C_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-g++.exe -DLIBUSB_LIBRARIES=C:/msys64/mingw64/lib/libusb-1.0.dll.a -DLIBUSB_INCLUDE_DIRS=C:/msys64/mingw64/include/libusb-1.0 -DBoost_USE_STATIC_LIBS=ON -DBUILD_STATIC_LIB=ON -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DBOOST_ROOT=C:/Libraries/boost_1_62_0 -DBUILD_PYTHON=OFF .. && cmake --build . --config %CONFIGURATION%"
+  - C:\msys64\usr\bin\bash -lc "cd C:/projects/libsmu/mingw-64 && cmake -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=/mingw64 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_C_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-g++.exe -DLIBUSB_LIBRARIES=C:/msys64/mingw64/lib/libusb-1.0.dll.a -DLIBUSB_INCLUDE_DIRS=C:/msys64/mingw64/include/libusb-1.0 -DBoost_USE_STATIC_LIBS=ON -DBUILD_STATIC_LIB=ON -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DBOOST_ROOT=C:/Libraries/boost_1_73_0 -DBUILD_PYTHON=OFF .. && cmake --build . --config %CONFIGURATION%"
 
   # Create libsmu zip artifact for 32 bit
   - mkdir c:\libsmu-%LIBSMU_VERSION%-MinGW-win32
@@ -450,62 +444,6 @@ build_script:
   - C:\msys64\usr\bin\bash -lc "cd c:/msys64/mingw64/bin ; cp -r libwinpthread-*.dll libgcc_*.dll libstdc++-*.dll libgomp-*.dll c:/libsmu-%LIBSMU_VERSION%-MinGW-win64"
   - 7z a "c:\libsmu-%LIBSMU_VERSION%-MinGW-win64.zip" c:\libsmu-%LIBSMU_VERSION%-MinGW-win64
   - appveyor PushArtifact c:\libsmu-%LIBSMU_VERSION%-MinGW-win64.zip
-
-  # Disable Python2 build for dist files.
-  ### Prepare for python bindings
-  ## build 32 bit python 2.7 bindings
-  #- "python2 --version"
-  #- "python2 -c \"import struct; print(struct.calcsize('P') * 8)\""
-  # update pip to keep it from complaining
-  #- "C:/msys64/mingw32/bin/python2.exe -m pip install --upgrade pip"
-  # wheel needs to be installed in order to build binary wheels for pysmu
-  #- "C:/msys64/mingw32/bin/python2.exe -m  pip install --only-binary :all: wheel"
-  # cython is required for generating the extensions
-  #- "C:/msys64/mingw32/bin/python2.exe -m  pip install cython"
-
-  # build python dist files
-  #- cd C:\projects\libsmu\bindings\python
-  #- "python2 setup.py build_ext --compiler=mingw32 -L C:\\projects\\libsmu\\mingw-32\\src -I C:\\msys64\\mingw64\\include\\libusb-1.0"
-  #- "python2 setup.py build"
-  #- "python2 setup.py bdist_wheel --skip-build"
-  #- "python2 setup.py bdist --skip-build --format msi"
-  #- ps: $PWD = Convert-Path .
-  #- ps: $PWD = $PWD + "\build-temp"
-  #- ps: $PWD
-  #- ps: $PWD = ($PWD -replace "\\","/").Trim("/")
-  #- ps: $PWD
-  #- ps: $env:PWDD=$PWD
-  #- "python2 setup.py bdist --format zip --bdist-base=%PWDD%"
-  # test local install
-  #- ps: Get-ChildItem dist/*-cp27-*-mingw.whl | % { pip2 install "$_" }
-  # Create a folder to keep pysmu for all the python versions
-  #- mkdir "pysmu-%LIBSMU_VERSION%-mingw-py"
-  #- 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*mingw.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%-mingw-py"
-
-  ## build 32 bit python 3.6 bindings
-  #- set PATH=C:\\msys64\\mingw32\\lib\\python3.6;C:\\msys64\\mingw32\\lib\\python3.6\\Tools\\scripts;%PATH%
-  #- "python3 --version"
-  #- "python3 -c \"import struct; print(struct.calcsize('P') * 8)\""
-  # update pip to keep it from complaining
-  #- "C:/msys64/mingw32/bin/python3.exe -m pip install --only-binary :all: --disable-pip-version-check --user --upgrade pip"
-  # wheel needs to be installed in order to build binary wheels for pysmu
-  #- "C:/msys64/mingw32/bin/python3.exe -m pip install --only-binary :all: wheel"
-  # cython is required for generating the extensions
-  #- "C:/msys64/mingw32/bin/python3.exe -m pip install cython"
-
-  # build python dist files
-  #- cd C:\projects\libsmu\bindings\python
-  #- "python3 setup.py build_ext --compiler=mingw32 -L C:\\projects\\libsmu\\mingw-32\\src -I C:\\libusb-mingw\\include\\libusb-1.0"
-  #- "python3 setup.py build"
-  #- "python3 setup.py bdist_wheel --skip-build"
-  #- "python3 setup.py bdist --skip-build --format msi"
-  #- "python3 setup.py bdist --format zip --bdist-base=%PWDD%"
-  # test local install
-  #- ps: Get-ChildItem dist/*-cp36-*-mingw.whl | % { pip3 install "$_" }
-   # Create a folder to keep pysmu for all the python versions
-  #- 7z x -y "c:\projects\libsmu\bindings\python\dist\pysmu*mingw.zip" -o"c:\projects\libsmu\bindings\python\pysmu-%LIBSMU_VERSION%-mingw-py"
-  #- 7z a -y "c:\projects\libsmu\bindings\python\dist\pysmu-%LIBSMU_VERSION%-mingw-py.zip" pysmu-*mingw-py
-  #- C:\msys64\usr\bin\bash -lc "rm dist/pysmu*mingw.zip"
 
   # push all dist files as artifacts
   - ps: Get-ChildItem dist/.\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -216,6 +216,31 @@ if (os.path.isfile(PY_INIT_FILE)):
                 version = m.group(1)
                 break
 
+    with open(PY_INIT_FILE, 'r+') as fd:
+        contents = fd.readlines()
+        pattern = "from .libsmu import"
+        import_pattern = "import os"
+
+        import_command = u"import os\n\n" + \
+        u"#Import DLLs for Python versions >= 3.8\n" + \
+        u"for path in os.environ.get(\"PATH\", \"\").split(os.pathsep):\n" + \
+        u"\tif path and os.path.isabs(path):\n" + \
+        u"\t\ttry:\n" + \
+        u"\t\t\tos.add_dll_directory(path)\n" + \
+        u"\t\texcept (OSError, AttributeError):\n" + \
+        u"\t\t\tcontinue\n\n"
+
+        for index, line in enumerate(contents):
+            #the script is run multiple times; this line prevents inserting the import command multuple times
+            if import_pattern in line:
+                break
+            if pattern in line:
+                contents.insert(index, import_command)
+                break
+
+        fd.seek(0)
+        fd.writelines(contents)
+
 if not version:
     raise RuntimeError('Cannot find version information')
 

--- a/dist/libsmu-x64.iss.cmakein
+++ b/dist/libsmu-x64.iss.cmakein
@@ -26,18 +26,13 @@ Name: "dutch"; MessagesFile: "compiler:Languages\Dutch.isl"
 Name: "finnish"; MessagesFile: "compiler:Languages\Finnish.isl"
 Name: "french"; MessagesFile: "compiler:Languages\French.isl"
 Name: "german"; MessagesFile: "compiler:Languages\German.isl"
-Name: "greek"; MessagesFile: "compiler:Languages\Greek.isl"
 Name: "hebrew"; MessagesFile: "compiler:Languages\Hebrew.isl"
-Name: "hungarian"; MessagesFile: "compiler:Languages\Hungarian.isl"
 Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
 Name: "polish"; MessagesFile: "compiler:Languages\Polish.isl"
 Name: "portuguese"; MessagesFile: "compiler:Languages\Portuguese.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
-Name: "scottishgaelic"; MessagesFile: "compiler:Languages\ScottishGaelic.isl"
-Name: "serbiancyrillic"; MessagesFile: "compiler:Languages\SerbianCyrillic.isl"
-Name: "serbianlatin"; MessagesFile: "compiler:Languages\SerbianLatin.isl"
 Name: "slovenian"; MessagesFile: "compiler:Languages\Slovenian.isl"
 Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
@@ -45,12 +40,12 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Files]
 Source: "C:\libsmu-python\pysmu27-amd64.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
-Source: "C:\libsmu-python\pysmu36-amd64.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
 Source: "C:\libsmu-python\pysmu37-amd64.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "C:\libsmu-python\pysmu38-amd64.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 Source: "C:\libsmu\64\*.dll"; DestDir: "{app}"; Flags: onlyifdoesntexist
 
-Source: "C:\WinDDK\7600.16385.1\redist\DIFx\dpinst\EngMui\amd64\dpinst.exe"; DestDir: "{app}\drivers"; Tasks: drivers
+Source: ".\pnputil.exe"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.inf"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.cat"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\amd64\*"; DestDir: "{app}\drivers\amd64"; Tasks: drivers
@@ -65,14 +60,15 @@ Name: drivers; Description: Install WinUSB drivers for the M1K;
 Name: modifypath; Description: Add application directory to your environmental path (required for smu utility);
 Name: visualstudio; Description: Install Visual Studio 2015 support for building/linking against libsmu; Flags: unchecked
 Name: python27; Description: Install python-2.7 bindings for libsmu; Flags: unchecked
-Name: python36; Description: Install python-3.6 bindings for libsmu; Flags: unchecked
 Name: python37; Description: Install python-3.7 bindings for libsmu; Flags: unchecked
+Name: python38; Description: Install python-3.8 bindings for libsmu; Flags: unchecked
 
 [Run]
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu27-amd64.msi"""; Flags: hidewizard; Tasks: python27
-Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu36-amd64.msi"""; Flags: hidewizard; Tasks: python36
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu37-amd64.msi"""; Flags: hidewizard; Tasks: python37
-Filename: "{app}\drivers\dpinst.exe"; Parameters: "/sa /path ""{app}\drivers"""; Flags: waituntilterminated; Tasks: drivers
+Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu38-amd64.msi"""; Flags: hidewizard; Tasks: python38
+Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.inf"" /install"; Flags: waituntilterminated; Tasks: drivers
+Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.cat"" /install"; Flags: waituntilterminated; Tasks: drivers
 
 [Code]
 const

--- a/dist/libsmu-x64.iss.cmakein
+++ b/dist/libsmu-x64.iss.cmakein
@@ -45,7 +45,7 @@ Source: "C:\libsmu-python\pysmu38-amd64.msi"; DestDir: "{tmp}"; Flags: deleteaft
 
 Source: "C:\libsmu\64\*.dll"; DestDir: "{app}"; Flags: onlyifdoesntexist
 
-Source: ".\pnputil.exe"; DestDir: "{app}\drivers"; Tasks: drivers
+Source: "C:\libsmu\drivers\dpinst_amd64.exe"; DestDir: "{app}\drivers"; DestName: "dpinst.exe"; Flags: ignoreversion
 Source: "C:\libsmu\drivers\m1k-winusb.inf"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.cat"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\amd64\*"; DestDir: "{app}\drivers\amd64"; Tasks: drivers
@@ -67,8 +67,7 @@ Name: python38; Description: Install python-3.8 bindings for libsmu; Flags: unch
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu27-amd64.msi"""; Flags: hidewizard; Tasks: python27
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu37-amd64.msi"""; Flags: hidewizard; Tasks: python37
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu38-amd64.msi"""; Flags: hidewizard; Tasks: python38
-Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.inf"" /install"; Flags: waituntilterminated; Tasks: drivers
-Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.cat"" /install"; Flags: waituntilterminated; Tasks: drivers
+Filename: "{app}\drivers\dpinst.exe"; Parameters: "/PATH ""{app}\drivers"" {param:dpinstflags|/F}"; Flags: waituntilterminated; Tasks: drivers
 
 [Code]
 const

--- a/dist/libsmu-x86.iss.cmakein
+++ b/dist/libsmu-x86.iss.cmakein
@@ -45,7 +45,7 @@ Source: "C:\libsmu-python\pysmu38-win32.msi"; DestDir: "{tmp}"; Flags: deleteaft
 
 Source: "C:\libsmu\32\*.dll"; DestDir: "{app}"; Flags: onlyifdoesntexist
 
-Source: ".\pnputil.exe"; DestDir: "{app}\drivers"; Tasks: drivers
+Source: "C:\libsmu\drivers\dpinst.exe"; DestDir: "{app}\drivers"; Flags: ignoreversion
 Source: "C:\libsmu\drivers\m1k-winusb.inf"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.cat"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\amd64\*"; DestDir: "{app}\drivers\amd64"; Tasks: drivers
@@ -67,8 +67,7 @@ Name: python38; Description: Install python-3.8 bindings for libsmu; Flags: unch
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu27-win32.msi"""; Flags: hidewizard; Tasks: python27
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu37-win32.msi"""; Flags: hidewizard; Tasks: python37
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu38-win32.msi"""; Flags: hidewizard; Tasks: python38
-Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.inf"" /install"; Flags: waituntilterminated; Tasks: drivers
-Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.cat"" /install"; Flags: waituntilterminated; Tasks: drivers
+Filename: "{app}\drivers\dpinst.exe"; Parameters: "/PATH ""{app}\drivers"" {param:dpinstflags|/F}"; Flags: waituntilterminated; Tasks: drivers
 
 [Code]
 const

--- a/dist/libsmu-x86.iss.cmakein
+++ b/dist/libsmu-x86.iss.cmakein
@@ -26,18 +26,13 @@ Name: "dutch"; MessagesFile: "compiler:Languages\Dutch.isl"
 Name: "finnish"; MessagesFile: "compiler:Languages\Finnish.isl"
 Name: "french"; MessagesFile: "compiler:Languages\French.isl"
 Name: "german"; MessagesFile: "compiler:Languages\German.isl"
-Name: "greek"; MessagesFile: "compiler:Languages\Greek.isl"
 Name: "hebrew"; MessagesFile: "compiler:Languages\Hebrew.isl"
-Name: "hungarian"; MessagesFile: "compiler:Languages\Hungarian.isl"
 Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
 Name: "polish"; MessagesFile: "compiler:Languages\Polish.isl"
 Name: "portuguese"; MessagesFile: "compiler:Languages\Portuguese.isl"
 Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
-Name: "scottishgaelic"; MessagesFile: "compiler:Languages\ScottishGaelic.isl"
-Name: "serbiancyrillic"; MessagesFile: "compiler:Languages\SerbianCyrillic.isl"
-Name: "serbianlatin"; MessagesFile: "compiler:Languages\SerbianLatin.isl"
 Name: "slovenian"; MessagesFile: "compiler:Languages\Slovenian.isl"
 Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
@@ -45,12 +40,12 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Files]
 Source: "C:\libsmu-python\pysmu27-win32.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
-Source: "C:\libsmu-python\pysmu36-win32.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
 Source: "C:\libsmu-python\pysmu37-win32.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "C:\libsmu-python\pysmu38-win32.msi"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 Source: "C:\libsmu\32\*.dll"; DestDir: "{app}"; Flags: onlyifdoesntexist
 
-Source: "C:\WinDDK\7600.16385.1\redist\DIFx\dpinst\EngMui\x86\dpinst.exe"; DestDir: "{app}\drivers"; Tasks: drivers
+Source: ".\pnputil.exe"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.inf"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\m1k-winusb.cat"; DestDir: "{app}\drivers"; Tasks: drivers
 Source: "C:\libsmu\drivers\amd64\*"; DestDir: "{app}\drivers\amd64"; Tasks: drivers
@@ -65,14 +60,15 @@ Name: drivers; Description: Install WinUSB drivers for the M1K;
 Name: modifypath; Description: Add application directory to your environmental path (required for smu utility);
 Name: visualstudio; Description: Install Visual Studio 2015 support for building/linking against libsmu; Flags: unchecked
 Name: python27; Description: Install python-2.7 bindings for libsmu; Flags: unchecked
-Name: python36; Description: Install python-3.6 bindings for libsmu; Flags: unchecked
 Name: python37; Description: Install python-3.7 bindings for libsmu; Flags: unchecked
+Name: python38; Description: Install python-3.8 bindings for libsmu; Flags: unchecked
 
 [Run]
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu27-win32.msi"""; Flags: hidewizard; Tasks: python27
-Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu36-win32.msi"""; Flags: hidewizard; Tasks: python36
 Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu37-win32.msi"""; Flags: hidewizard; Tasks: python37
-Filename: "{app}\drivers\dpinst.exe"; Parameters: "/sa /path ""{app}\drivers"""; Flags: waituntilterminated; Tasks: drivers
+Filename: "msiexec.exe"; Parameters: "/i ""{tmp}\pysmu38-win32.msi"""; Flags: hidewizard; Tasks: python38
+Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.inf"" /install"; Flags: waituntilterminated; Tasks: drivers
+Filename: "{app}\drivers\pnputil.exe"; Parameters: "/add-driver ""{app}\drivers\m1k-winusb.cat"" /install"; Flags: waituntilterminated; Tasks: drivers
 
 [Code]
 const


### PR DESCRIPTION
The following changes were made:
- the Visual Studio 2015 image wasn't compatible with pacman anymore. Upgraded it to VS 2019 and its specific dependencies (boost 1.73 and the current VS redistributables);
- Updated supported Python versions: removed 3.6 and added 3.8;
- In Python 3.8 the .pyd/.dll file import mechanism was changed. Implemented the necessary modifications to support pysmu's importing for Python 3.8.
- updated libusb version to 1.0.23; v1.0.24 is not compatible with the Python bindings because it defines some symbols which conflicts with the Python libraries;
- dpinst.exe is not supported in the latest Windows 10 releases; changed it with pnputil.exe;
- iscc removed some language packages; I removed them from out installer as well;
- removed some redundant commands from the appveyor.yml file.