### PR TITLE
Fix py3.10 issue

### DIFF
--- a/bindings/python/pysmu/utils.py
+++ b/bindings/python/pysmu/utils.py
@@ -1,5 +1,7 @@
-from collections import Iterable
-
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 def iterify(x):
     """Return an iterable form of a given value."""


### PR DESCRIPTION
Python 3.10 changed the module of Iterable to have a different path. This fixes that issues and is backward compatible.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>