### PR TITLE
fixed bug in python cmake binding

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 set(CMAKE_VERBOSE_MAKEFILE ON)


### PR DESCRIPTION
Cmake version 3.4 wrongly identifies the python path. In particular, it picks system python rather than the local currently active (conda or virtualenv), resulting in an error - a rather untrivial case, made me think a lot to figure that out.

I haven't checked which CMake version fixes this, but 3.18 works fine.