### PR TITLE
libsmu.pc.cmakein: use FULL paths

### DIFF
--- a/dist/libsmu.pc.cmakein
+++ b/dist/libsmu.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: libsmu
 Description: Library for interfacing with M1K devices


### PR DESCRIPTION
it's apparently a common mistake
https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path

this change is needed to build this for Nixpkgs